### PR TITLE
Add llvm-dpcpp dependency for DPC++ compiler

### DIFF
--- a/compiler/debian/changelog
+++ b/compiler/debian/changelog
@@ -1,3 +1,9 @@
+intel-dpcpp (6.1.0-0ubuntu1~25.10~ppa18) plucky; urgency=medium
+
+  * dpcpp: add dependency since compiler needs various llvm-* commands to work.
+
+ -- Will French <will.french@canonical.com>  Thu, 10 Jul 2025 14:37:25 -0500
+
 intel-dpcpp (6.1.0-0ubuntu1~25.10~ppa17) plucky; urgency=medium
 
   * dpcpp: lintian cleanup and improve package descriptions.

--- a/compiler/debian/control
+++ b/compiler/debian/control
@@ -34,7 +34,8 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  libsycl-dev,
- libclang-dpcpp-common-20-dev
+ libclang-dpcpp-common-20-dev,
+ llvm-dpcpp
 Description: Intel DPC++ compiler
  DPC++ is a LLVM-based compiler project that implements compiler and runtime
  support for the SYCL* language.


### PR DESCRIPTION
The `clang++-dpcpp` command depends on a number of the `llvm-` commands [1], so this adds a dependency between the packages.

[1] For example, without the `llvm-dpcpp` package installed you see errors like the following:

```bash
$ clang++-dpcpp -fsycl sample.cpp -o simple-sycl-app
clang++-dpcpp: error: unable to execute command: Executable "/usr/lib/llvm-dpcpp-20/bin/llvm-link" doesn't exist!
```