### PR TITLE
dpcpp: add symlink for sycl-ls so it is in the PATH

### DIFF
--- a/compiler/debian/changelog
+++ b/compiler/debian/changelog
@@ -1,3 +1,9 @@
+intel-dpcpp (6.1.0-0ubuntu1~25.10~ppa19) plucky; urgency=medium
+
+  * dpcpp: add symlink for sycl-ls so it is in the PATH.
+
+ -- Will French <will.french@canonical.com>  Fri, 11 Jul 2025 08:32:37 -0500
+
 intel-dpcpp (6.1.0-0ubuntu1~25.10~ppa18) plucky; urgency=medium
 
   * dpcpp: add dependency since compiler needs various llvm-* commands to work.

--- a/compiler/debian/clang-dpcpp-20.links
+++ b/compiler/debian/clang-dpcpp-20.links
@@ -3,3 +3,4 @@ usr/lib/llvm-dpcpp-20/bin/clang++ usr/bin/clang++-dpcpp
 usr/lib/llvm-dpcpp-20/bin/clang-cpp usr/bin/clang-cpp-dpcpp
 usr/lib/llvm-dpcpp-20/bin/clang-cl usr/bin/clang-cl-dpcpp
 usr/lib/llvm-dpcpp-20/bin/spirv-to-ir-wrapper usr/bin/spirv-to-ir-wrapper
+usr/lib/llvm-dpcpp-20/bin/sycl-ls usr/bin/sycl-ls


### PR DESCRIPTION
`sycl-ls` is a convenient tool for users to check the devices that the compiler runtime can see. 