### PR TITLE
Release packages for resolute

### DIFF
--- a/compiler/debian/changelog
+++ b/compiler/debian/changelog
@@ -1,3 +1,9 @@
+intel-dpcpp (6.2.0-0ubuntu1~26.04~ppa1) resolute; urgency=medium
+
+  * Build for resolute.
+
+ -- Will French <will.french@canonical.com>  Wed, 29 Oct 2025 13:15:21 -0500
+
 intel-dpcpp (6.2.0-0ubuntu1~25.10~ppa1) questing; urgency=medium
 
   * Build for questing.

--- a/compiler/debian/changelog
+++ b/compiler/debian/changelog
@@ -1,3 +1,10 @@
+intel-dpcpp (6.2.0-0ubuntu1~26.04~ppa2) resolute; urgency=medium
+
+  * Support new version of OpenCL.
+  * https://github.com/intel/llvm/issues/20511
+
+ -- Will French <will.french@canonical.com>  Thu, 06 Nov 2025 08:50:44 +0000
+
 intel-dpcpp (6.2.0-0ubuntu1~26.04~ppa1) resolute; urgency=medium
 
   * Build for resolute.

--- a/compiler/debian/patches/series
+++ b/compiler/debian/patches/series
@@ -2,3 +2,4 @@ sycl-0001-ubuntu-sauce.patch
 ur-0001-fix-opencl-lib.patch
 clang-0001-remove-cpp-driver-suffix.patch
 ur-0002-does-not-copy-level-zero-loader-headers-around.patch
+ur-0003-support-resolute-opencl.patch

--- a/compiler/debian/patches/ur-0003-support-resolute-opencl.patch
+++ b/compiler/debian/patches/ur-0003-support-resolute-opencl.patch
@@ -1,0 +1,55 @@
+Description: Support new version of OpenCL.
+ This enables support for the new version of OpenCL that ships
+ with resolute.
+ https://github.com/intel/llvm/issues/20511
+Author: Will French <will.french@canonical.com>
+Last-Update: 2025-11-06
+---
+--- intel-dpcpp-6.2.0.orig/unified-runtime/source/adapters/opencl/CMakeLists.txt
++++ intel-dpcpp-6.2.0/unified-runtime/source/adapters/opencl/CMakeLists.txt
+@@ -57,7 +57,7 @@ if(UR_OPENCL_INCLUDE_DIR)
+ else()
+     FetchContent_Declare(OpenCL-Headers
+         GIT_REPOSITORY  "https://github.com/KhronosGroup/OpenCL-Headers.git"
+-        GIT_TAG         542d7a8f65ecfd88b38de35d8b10aa67b36b33b2
++        GIT_TAG         "v2025.07.22"
+     )
+     FetchContent_MakeAvailable(OpenCL-Headers)
+     FetchContent_GetProperties(OpenCL-Headers
+@@ -79,7 +79,7 @@ else()
+     if(NOT OpenCL_FOUND)
+         FetchContent_Declare(OpenCL-ICD-Loader
+             GIT_REPOSITORY  "https://github.com/KhronosGroup/OpenCL-ICD-Loader.git"
+-            GIT_TAG         main
++            GIT_TAG         "v2025.07.22"
+         )
+         FetchContent_MakeAvailable(OpenCL-ICD-Loader)
+     endif()
+@@ -94,6 +94,7 @@ message(STATUS "OpenCL ICD Loader Librar
+ target_compile_definitions(ur_adapter_opencl PRIVATE
+     CL_TARGET_OPENCL_VERSION=300
+     CL_USE_DEPRECATED_OPENCL_1_2_APIS
++    CL_ENABLE_BETA_EXTENSIONS=ON
+ )
+ 
+ target_include_directories(${TARGET_NAME} PRIVATE
+--- intel-dpcpp-6.2.0.orig/unified-runtime/source/adapters/opencl/memory.cpp
++++ intel-dpcpp-6.2.0/unified-runtime/source/adapters/opencl/memory.cpp
+@@ -205,6 +205,8 @@ cl_image_format mapURImageFormatToCL(con
+ 
+ cl_image_desc mapURImageDescToCL(const ur_image_desc_t *PImageDesc) {
+   cl_image_desc CLImageDesc;
++  memset(&CLImageDesc, 0, sizeof(CLImageDesc));
++
+   CLImageDesc.image_type =
+       cl_adapter::cast<cl_mem_object_type>(PImageDesc->type);
+ 
+@@ -237,8 +239,6 @@ cl_image_desc mapURImageDescToCL(const u
+   CLImageDesc.image_slice_pitch = PImageDesc->slicePitch;
+   CLImageDesc.num_mip_levels = PImageDesc->numMipLevel;
+   CLImageDesc.num_samples = PImageDesc->numSamples;
+-  CLImageDesc.buffer = nullptr;
+-  CLImageDesc.mem_object = nullptr;
+ 
+   return CLImageDesc;
+ }

--- a/emhash/debian/changelog
+++ b/emhash/debian/changelog
@@ -1,3 +1,9 @@
+emhash (1.0.0-0ubuntu1~26.04~ppa1) resolute; urgency=medium
+
+  * Build for resolute.
+
+ -- Will French <will.french@canonical.com>  Wed, 29 Oct 2025 13:21:17 -0500
+
 emhash (1.0.0-0ubuntu1~25.10~ppa1) questing; urgency=medium
 
   * Build for questing.

--- a/onedpl/debian/changelog
+++ b/onedpl/debian/changelog
@@ -1,3 +1,9 @@
+onedpl (2022.9.0-0ubuntu1~26.04~ppa1) resolute; urgency=medium
+
+  * Build for resolute.
+
+ -- Will French <will.french@canonical.com>  Wed, 29 Oct 2025 13:26:25 -0500
+
 onedpl (2022.9.0-0ubuntu1~25.10~ppa1) questing; urgency=medium
 
   * Build for questing.

--- a/umf/debian/changelog
+++ b/umf/debian/changelog
@@ -1,3 +1,9 @@
+intel-umf (0.11.0-0ubuntu1~26.04~ppa1) resolute; urgency=medium
+
+  * Build for resolute.
+
+ -- Will French <will.french@canonical.com>  Wed, 29 Oct 2025 13:16:44 -0500
+
 intel-umf (0.11.0-0ubuntu1~25.10~ppa1) questing; urgency=medium
 
   * Build for questing. 


### PR DESCRIPTION
These packages are now published to the oneapi-release PPA. Note that for the compiler we need to patch the OpenCL adapter to work with the new version of OpenCL that ships with resolute. See https://github.com/intel/llvm/issues/20511 for more background.