### PR TITLE
onednn: append -sycl to source pkg name

### DIFF
--- a/onednn/README.md
+++ b/onednn/README.md
@@ -7,7 +7,7 @@ Note, debian and Ubuntu ship their own [onednn source package](https://launchpad
 ```bash
 uscan --download-version=3.10.2
 cd ..
-tar xvf onednn_3.10.2.orig.tar.xz
+tar xvf onednn-sycl_3.10.2.orig.tar.xz
 cd uxlfoundation-oneDNN-*
 cp -r ../onednn/debian .
 ```

--- a/onednn/debian/changelog
+++ b/onednn/debian/changelog
@@ -1,12 +1,5 @@
-onednn (3.10.2-0ubuntu2~26.04) resolute; urgency=medium
+onednn-sycl (3.10.2-0ubuntu3~26.04) resolute; urgency=medium
 
-  * Initial package upload (LP: #2136925).
-    - d/libdnnl-sycl3.symbols: add Build-Depends-Package field.
+  * Initial release. (LP: #2136925)
 
- -- Will French <will.french@canonical.com>  Wed, 14 Jan 2026 10:38:28 -0600
-
-onednn (3.10.2-0ubuntu1~26.04) resolute; urgency=medium
-
-  * Initial package upload (LP: #2136925).
-
- -- Will French <will.french@canonical.com>  Tue, 13 Jan 2026 01:35:00 +0000
+ -- Will French <will.french@canonical.com>  Tue, 20 Jan 2026 09:44:13 -0600

--- a/onednn/debian/control
+++ b/onednn/debian/control
@@ -1,4 +1,4 @@
-Source: onednn
+Source: onednn-sycl
 Section: science
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>


### PR DESCRIPTION
This updates the onednn source package name to `onednn-sycl` to avoid collisions with the existing `onednn` source package in debian and Ubuntu. More details about the motivation for this change can be found in the needs-packaging bug here: https://bugs.launchpad.net/ubuntu/+bug/2136925