### PR TITLE
oneDPL: feature freeze exception

### DIFF
--- a/onedpl/debian/changelog
+++ b/onedpl/debian/changelog
@@ -1,3 +1,16 @@
+onedpl (2022.9.0-0ubuntu6) resolute; urgency=medium
+
+  * d/tests:
+    - Update binary package name for DPC++ compiler from
+    clang-dpcpp-21 to dpclang-6.
+    - Update DPC++ compiler name from clang++-dpcpp to
+    dpclang++.
+  * d/changelog: drop ~26.04 suffix from version as this
+  was intended to be dropped when the package migrated
+  from a PPA to the archive.
+
+ -- Will French <will.french@canonical.com>  Fri, 20 Mar 2026 13:13:24 -0500
+
 onedpl (2022.9.0-0ubuntu5~26.04) resolute; urgency=medium
 
   * Initial package upload (LP: #2130191)

--- a/onedpl/debian/tests/binary-search
+++ b/onedpl/debian/tests/binary-search
@@ -3,7 +3,7 @@
 set -e
 
 echo -e "\033[1;34m>>> [${0}] Starting build phase\033[0m"
-clang++-dpcpp -fsycl "$(dirname "$0")/002-binary-search/binary_search.cpp" -w -o binary_search
+dpclang++ -fsycl "$(dirname "$0")/002-binary-search/binary_search.cpp" -w -o binary_search
 
 echo -e "\033[1;34m>>> [${0}] Starting run phase\033[0m"
 ./binary_search

--- a/onedpl/debian/tests/control
+++ b/onedpl/debian/tests/control
@@ -1,4 +1,4 @@
 Tests: reduce-segment, binary-search, dpl-sortdouble
 # tests all require the DPC++ compiler to build samples
-Depends: @, clang-dpcpp-21
+Depends: @, dpclang-6
 Restrictions: allow-stderr

--- a/onedpl/debian/tests/dpl-sortdouble
+++ b/onedpl/debian/tests/dpl-sortdouble
@@ -3,7 +3,7 @@
 set -e
 
 echo -e "\033[1;34m>>> [${0}] Starting build phase\033[0m"
-clang++-dpcpp -fsycl "$(dirname "$0")/003-dpl-sortdouble/dpl_sortdouble.cpp" -w -o dpl_sortdouble
+dpclang++ -fsycl "$(dirname "$0")/003-dpl-sortdouble/dpl_sortdouble.cpp" -w -o dpl_sortdouble
 
 echo -e "\033[1;34m>>> [${0}] Starting run phase\033[0m"
 ./dpl_sortdouble

--- a/onedpl/debian/tests/reduce-segment
+++ b/onedpl/debian/tests/reduce-segment
@@ -3,7 +3,7 @@
 set -e
 
 echo -e "\033[1;34m>>> [${0}] Starting build phase\033[0m"
-clang++-dpcpp -fsycl "$(dirname "$0")/001-reduce-segment/reduce_segment.cpp" -w -o reduce_segment
+dpclang++ -fsycl "$(dirname "$0")/001-reduce-segment/reduce_segment.cpp" -w -o reduce_segment
 
 echo -e "\033[1;34m>>> [${0}] Starting run phase\033[0m"
 ./reduce_segment


### PR DESCRIPTION
This updates the onedpl package based on changes in https://github.com/canonical/oneapi-packaging/pull/39. Specifically:

* Update to binary package name for the DPC++ compiler used to build autopkgtests
* Update to compiler commands used to build `onedpl` autopkgtests

The new release (2022.9.0-0ubuntu6 ) is published in the [kobuk-team:oneapi-resolute-ffes PPA](https://launchpad.net/~kobuk-team/+archive/ubuntu/oneapi-resolute-ffes).

## autopkgtests

* Host system

``` shell
$ uname -r
7.0.0-7-generic

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu Resolute Raccoon (development branch)
Release:	26.04
Codename:	resolute

$ lspci -nn | grep -i graph
00:02.0 VGA compatible controller [0300]: Intel Corporation Meteor Lake-P [Intel Arc Graphics] [8086:7d55] (rev 08)

$ apt list --installed | grep dpclang-6
dpclang-6/resolute,now 6.2.0-0ubuntu2 amd64 [installed]

$ apt list --installed | grep onedpl
onedpl-headers/resolute,now 2022.9.0-0ubuntu6 amd64 [installed]
```

* Test source

```shell
$ cd ~/oneapi-packaging-feature-freeze-exceptions/onedpl/

$ git remote -v
origin	https://github.com/canonical/oneapi-packaging.git (fetch)
origin	https://github.com/canonical/oneapi-packaging.git (push)

$ git branch
* onedpl/feature-freeze-exception
```

* Results

```shell
$ autopkgtest -B -- null
autopkgtest [15:08:24]: starting date and time: 2026-03-26 15:08:24+0000
autopkgtest [15:08:24]: version 5.55
autopkgtest [15:08:24]: host hercules-542967; command line: /usr/bin/autopkgtest -B -- null
autopkgtest [15:08:24]: testbed dpkg architecture: amd64
autopkgtest [15:08:24]: testbed apt version: 3.1.16
autopkgtest [15:08:24]: @@@@@@@@@@@@@@@@@@@@ test bed setup
autopkgtest [15:08:24]: testbed release detected to be: resolute
autopkgtest [15:08:24]: testbed running kernel: Linux 7.0.0-7-generic #7-Ubuntu SMP PREEMPT_DYNAMIC Thu Mar 12 11:34:39 UTC 2026
autopkgtest [15:08:24]: @@@@@@@@@@@@@@@@@@@@ unbuilt-tree .
autopkgtest [15:08:24]: testing package onedpl version 2022.9.0-0ubuntu6
autopkgtest [15:08:24]: build not needed
autopkgtest [15:08:24]: test reduce-segment: preparing testbed
autopkgtest [15:08:24]: test reduce-segment: [-----------------------
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/reduce-segment] Starting build phase
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/reduce-segment] Starting run phase
Device : Intel(R) Arc(TM) Graphics
Keys = [ 0 0 0 1 1 1 ]
Values = [ 1 2 3 4 5 6 ]
Output Keys = [ 0 1 ]
Output Values = [ 6 15 ]
autopkgtest [15:08:34]: test reduce-segment: -----------------------]
autopkgtest [15:08:34]: test reduce-segment:  - - - - - - - - - - results - - - - - - - - - -
reduce-segment       PASS
autopkgtest [15:08:34]: test binary-search: preparing testbed
autopkgtest [15:08:34]: test binary-search: [-----------------------
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/binary-search] Starting build phase
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/binary-search] Starting run phase
Device : Intel(R) Arc(TM) Graphics
Input sequence = [0 2 2 2 3 3 3 3 6 6 ]
Search sequence = [0 2 4 7 6 ]
Search results = [1 1 0 0 1 ]
autopkgtest [15:08:41]: test binary-search: -----------------------]
autopkgtest [15:08:41]: test binary-search:  - - - - - - - - - - results - - - - - - - - - -
binary-search        PASS
autopkgtest [15:08:41]: test dpl-sortdouble: preparing testbed
autopkgtest [15:08:42]: test dpl-sortdouble: [-----------------------
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/dpl-sortdouble] Starting build phase
>>> [/tmp/autopkgtest.JSlAuQ/build.oti/real-tree/debian/tests/dpl-sortdouble] Starting run phase
Device : Intel(R) Arc(TM) Graphics
2
4
6
8
autopkgtest [15:08:52]: test dpl-sortdouble: -----------------------]
autopkgtest [15:08:52]: test dpl-sortdouble:  - - - - - - - - - - results - - - - - - - - - -
dpl-sortdouble       PASS
autopkgtest [15:08:52]: @@@@@@@@@@@@@@@@@@@@ summary
reduce-segment       PASS
binary-search        PASS
dpl-sortdouble       PASS
```