### PR TITLE
Update project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # oneAPI Packaging for Ubuntu :rocket:
 
-This repo contains Debian package definitions for components from the [oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html). These packages are built from open source implementations, which may differ in functionality from the closed sourced versions available in Intel's official repositories (e.g. the compiler).
+This repo contains Debian package definitions for components from the [oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html). These packages are built from open source implementations, which may differ in functionality from the closed sourced versions provided by Intel.
 
-The packages are now available directly from the Ubuntu archive beginning in Ubuntu 26.04 (Resolute Raccoon).
+The packages are available directly from the Ubuntu archive beginning in Ubuntu 26.04 (Resolute Raccoon).
 
 1. [Enable Intel GPU support](#1-optional-enable-intel-gpu-support)
-2. [Install packages from the Ubuntu Archive](#2-install-packages-from-the-ubuntu-archive)
+2. [Install packages from the Ubuntu archive](#2-install-packages-from-the-ubuntu-archive)
 3. [Build and run SYCL* applications](#3-build-and-run-sycl-applications)
 
 > [!IMPORTANT]
@@ -22,7 +22,7 @@ sudo usermod -a -G render $USER
 
 You need to log out and log back in for this change to take effect.
 
-## 2. Install packages from the Ubuntu Archive
+## 2. Install packages from the Ubuntu archive
 
 ### 2.1 DPC++ compiler
 
@@ -44,6 +44,8 @@ sudo apt install libdnnl-sycl3
 
 ## 3. Build and run SYCL* applications
 
+This section briefly describes the basics of getting started with these tools and libraries on Ubuntu. Please refer to Intel documentation for a more complete guide.
+
 Applications written in SYCL* C++ can be compiled using the `dpclang++` command. For example:
 
 ```bash
@@ -51,32 +53,18 @@ dpclang++ -fsycl sample.cpp -o simple-sycl-app
 ./simple-sycl-app
 ```
 
-Alternatively, use `pkg-config` to discover details for `libsycl` at build-time:
-
-```bash
-$ pkg-config --cflags sycl-dpcpp-6
--I/usr/lib/dpclang-6/llvm/include
-$ pkg-config --libs sycl-dpcpp-6
--L/usr/lib/dpclang-6/llvm/lib -lsycl
-$ pkg-config --modversion sycl-dpcpp-6
-6.2.0
-```
+This command will also work if `sample.cpp` contains references to header files from the oneDPL library, assuming you have the `onedpl-headers` package installed.
 
 ### 3.1 Build and run SYCL* applications with oneDNN
 
-In addition to `dpclang-6`, install the oneDNN-SYCL development package:
+To build with oneDNN support, install the oneDNN-SYCL development package and optionally other common development packages
 
 ```bash
 sudo apt install libdnnl-sycl-dev
+sudo apt install libtbb-dev ocl-icd-opencl-dev # optional
 ```
 
-Optionally, also install oneTBB and OpenCL development packages if they are needed by your application:
-
-```bash
-sudo apt install libtbb-dev ocl-icd-opencl-dev
-```
-
-Now pass the library names in your compile command, for example:
+Now pass the library names in your compile command (this example assumes your application also uses OpenCL and oneTBB), for example:
 
 ```bash
 dpclang++ -fsycl -ldnnl-sycl -lOpenCL -ltbb sample.cpp -o sample-onednn-sycl-app
@@ -85,7 +73,7 @@ dpclang++ -fsycl -ldnnl-sycl -lOpenCL -ltbb sample.cpp -o sample-onednn-sycl-app
 
 CMake configuration files are delivered by the `libdnnl-sycl-dev` package to support applications built with CMake.
 
-Finally, there are also examples available from the `onednn-examples` binary package that can be used as a helpful reference for application developers:
+Finally, there are examples available from the `onednn-examples` binary package that can be used as a helpful reference for application developers:
 
 ```bash
 sudo apt install onednn-examples

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # oneAPI Packaging for Ubuntu :rocket:
 
-This repo contains Debian package definitions for components from the [oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html) published to the following PPA:
+This repo contains Debian package definitions for components from the [oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html). These packages are built from open source implementations, which may differ in functionality from the closed sourced versions available in Intel's official repositories (e.g. the compiler).
 
-- [ppa:kobuk-team/oneapi-release](https://launchpad.net/~kobuk-team/+archive/ubuntu/oneapi-release)
-
-The latest packages are built for and validated against Ubuntu 26.04 (Resolute Raccoon).
+The packages are now available directly from the Ubuntu archive beginning in Ubuntu 26.04 (Resolute Raccoon).
 
 1. [Enable Intel GPU support](#1-optional-enable-intel-gpu-support)
-2. [Add the PPA to apt sources](#2-add-the-ppa-to-apt-sources)
-3. [Install packages from the PPA](#3-install-packages-from-the-ppa)
-4. [Build and run SYCL* applications](#4-build-and-run-sycl-applications)
+2. [Install packages from the Ubuntu Archive](#2-install-packages-from-the-ubuntu-archive)
+3. [Build and run SYCL* applications](#3-build-and-run-sycl-applications)
+
+> [!IMPORTANT]
+>
+> This repo is intended for development of new package definitions. Once packages have landed in the Ubuntu archive, the source of truth for these packages is Launchpad.
 
 ## 1. Enable Intel GPU support
 
@@ -19,64 +20,76 @@ To run SYCL* applications with Intel GPU support, ensure you have permissions to
 sudo usermod -a -G render $USER
 ```
 
-You need to log out and log back for this change to take effect.
+You need to log out and log back in for this change to take effect.
 
-## 2. Add the PPA to apt sources
+## 2. Install packages from the Ubuntu Archive
 
-```bash
-sudo add-apt-repository ppa:kobuk-team/oneapi-release
-sudo apt update
-```
-
-## 3. Install packages from the PPA
-
-### 3.1 DPC++ compiler
+### 2.1 DPC++ compiler
 
 ```bash
-sudo apt install clang-dpcpp-21
+sudo apt install dpclang-6
 ```
 
-### 3.2 oneDPL library
+### 2.2 oneDPL library
 
 ```bash
 sudo apt install onedpl-headers
 ```
 
-### 3.3 oneDNN library
+### 2.3 oneDNN library
 
 ```bash
 sudo apt install libdnnl-sycl3
 ```
 
-## 4. Build and run SYCL* applications
+## 3. Build and run SYCL* applications
 
-Applications written in SYCL* C++ can be compiled using the `clang++-dpcpp` command. For example:
+Applications written in SYCL* C++ can be compiled using the `dpclang++` command. For example:
 
 ```bash
-clang++-dpcpp -fsycl sample.cpp -o simple-sycl-app
+dpclang++ -fsycl sample.cpp -o simple-sycl-app
 ./simple-sycl-app
 ```
 
-### 4.1 Build and run SYCL* applications with oneDNN
-
-First make sure to install all the required development packages:
+Alternatively, use `pkg-config` to discover details for `libsycl` at build-time:
 
 ```bash
-sudo apt install libdnnl-sycl-dev libtbb-dev ocl-icd-opencl-dev libsycl-dev libclang-dpcpp-common-21-dev
+$ pkg-config --cflags sycl-dpcpp-6
+-I/usr/lib/dpclang-6/llvm/include
+$ pkg-config --libs sycl-dpcpp-6
+-L/usr/lib/dpclang-6/llvm/lib -lsycl
+$ pkg-config --modversion sycl-dpcpp-6
+6.2.0
+```
+
+### 3.1 Build and run SYCL* applications with oneDNN
+
+In addition to `dpclang-6`, install the oneDNN-SYCL development package:
+
+```bash
+sudo apt install libdnnl-sycl-dev
+```
+
+Optionally, also install oneTBB and OpenCL development packages if they are needed by your application:
+
+```bash
+sudo apt install libtbb-dev ocl-icd-opencl-dev
 ```
 
 Now pass the library names in your compile command, for example:
 
 ```bash
-clang++-dpcpp -fsycl -ldnnl-sycl -lOpenCL -ltbb sample.cpp -o sample-onednn-sycl-app
+dpclang++ -fsycl -ldnnl-sycl -lOpenCL -ltbb sample.cpp -o sample-onednn-sycl-app
 ./simple-onednn-sycl-app
 ```
 
-There are also examples available from the `onednn-examples` binary package:
+CMake configuration files are delivered by the `libdnnl-sycl-dev` package to support applications built with CMake.
+
+Finally, there are also examples available from the `onednn-examples` binary package that can be used as a helpful reference for application developers:
 
 ```bash
 sudo apt install onednn-examples
 cp /usr/lib/onednn/examples/getting_started.cpp .
-clang++dpcpp -fsycl -I /usr/lib/onednn/examples -ldnnl-sycl -lOpenCL -ltbb getting_started.cpp -o getting-started
+dpclang++ -fsycl -I /usr/lib/onednn/examples -ldnnl-sycl -lOpenCL -ltbb getting_started.cpp -o getting-started
 ./getting-started gpu
 ```

--- a/compiler/debian/changelog
+++ b/compiler/debian/changelog
@@ -1,134 +1,137 @@
 intel-dpcpp (6.2.0-0ubuntu2) resolute; urgency=medium
 
-  * d/control:
-    - Update binary package names based on recommendations from Intel.
-    https://github.com/canonical/oneapi-packaging/issues/36
-    - Add missing runtime dependencies for dpclang-6 binary package.
-    https://github.com/canonical/oneapi-packaging/issues/30
-    https://github.com/canonical/oneapi-packaging/issues/31
-    - Remove libur-loader0 binary package since it's now built as a static
-    lib.
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Remove libur-adapter* binary packages and consolidate into a single
-    unified-runtime-adapters-dpcpp-6 binary package since these
-    libs are no longer in a public directory.
-    https://github.com/canonical/oneapi-packaging/issues/37
-    - Remove libur-loader* binary packages since this lib is
-    now built statically.
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Add dependency between libclang-dpcpp-6-dev and sycl-dpcpp-6-dev
-    since the clang development package now includes the unified runtime
-    loader headers that are needed for compiling SYCL applications.
-    - Add strict version constraints for all binary packages derived
-    from the same intel-dpcpp source package, with the exception of
-    libsycl8 since it may be used by multiple versions of DPC++.
-    - Add Replaces and Breaks fields where package names have changed
-    to ensure a smooth upgrade for users who have the previous package
-    names installed.
-  * d/rules:
-    - Remove spirv-to-ir-wrapper man page since it is no longer
-    in a public directory.
-    https://github.com/canonical/oneapi-packaging/issues/35
-    - Build unified runtime lib statically.
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Update man page names because name of public symlinks have changed;
-    update excluded private compiler path for dh_makeshlibs.
-    https://github.com/canonical/oneapi-packaging/issues/34
-  * d/*.{install,manpages,links}: update private compiler path from
-  /usr/lib/llvm-dpcpp-21 to /usr/lib/dpcpp-6/llvm
-  https://github.com/canonical/oneapi-packaging/issues/34
-  * d/dpclang-6.links:
-    - Update symlink names based on feedback from Intel.
-    https://github.com/canonical/oneapi-packaging/issues/34
-    - Remove spirv-to-ir-wrapper symlink since it is compiler-private.
-    https://github.com/canonical/oneapi-packaging/issues/35
-  * d/libsycl8.install:
-    - Install .spv files required for supporting -fsycl-device-lib-jit-link
-    option.
-    https://github.com/canonical/oneapi-packaging/issues/32
-    - Install versioned .so in private directory so it can find .spv
-    files at runtime.
-    https://github.com/canonical/oneapi-packaging/issues/32
-  * d/libsycl8.links: Sym link from public to private path.
-  https://github.com/canonical/oneapi-packaging/issues/32
-  * d/libsycl8.symbols: Update Build-Depends-Package field since
-  libsycl-dev is now sycl-dpcpp-6-dev.
-  * d/libsycl8.lintian-overrides: Add lintian-override and explain
-  why ldconfig trigger is not needed for private library.
-  * d/sycl-dpcpp-6-dev.install:
-    - Install .bc files required during compilation.
-    https://github.com/canonical/oneapi-packaging/issues/32
-    - Install sycl-dpcpp-6.pc pkgconfig file
-    https://github.com/canonical/oneapi-packaging/issues/42
-    - Remove redundant openCL header files from opencl-c-headers.
-    Keep CL/sycl.hpp for backwards compatibility.
-    - Migrate unified runtime loader header files and XPTI header
-    files to libclang-dpcpp-6-dev binary package.
-  * d/sycl-dpcpp-6-dev.links:
-    - Create development sym link manually since upstream
-    uses relative path.
-    https://github.com/canonical/oneapi-packaging/issues/32
-    https://github.com/canonical/oneapi-packaging/issues/35
-    - Move libsycl.so development symlink to compiler-private
-    directory to avoid future conflicts where a user may want
-    multiple versions of dpclang and libsycl installed at the
-    same time.
-    - Symlink to sycl-dpcpp-6.pc pkgconfig file
-    https://github.com/canonical/oneapi-packaging/issues/42
-  * d/sycl-dpcpp-6.pc: add pkgconfig file for libsycl, needed
-    for users who want to link with libsycl directly.
-  * d/p/series:
-    - Apply new patch for building libur as a static lib.
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Drop clang-0001-remove-cpp-driver-suffix.patch because new clang*
-    symlink names do not collid with any suffix names from upstream.
-    https://github.com/canonical/oneapi-packaging/issues/34
-    - Apply new patch for fixing mock in unit tests
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Apply new patch to remove xptiFrameworkFinalize call
-    https://github.com/canonical/oneapi-packaging/issues/33
-    - Apply new patch for resolving loader lib path.
-    - Apply patch for adding in source versioning to DPC++
-    https://github.com/intel/llvm/issues/21509
-    - Apply patch for adding self-macro versioning to DPC++
-    https://github.com/intel/llvm/issues/21510
-  * d/p/clang-0001-remove-cpp-driver-suffix.patch: drop patch
-  because new clang* symlink names do not collide with any suffix
-  names from upstream.
-  https://github.com/canonical/oneapi-packaging/issues/34
-  * d/p/ur-0004-fix-static-loader-when-building-in-tree.patch:
-  Build unified runtime loader as a static lib since its API/ABI
-  are unstable.
-  https://github.com/canonical/oneapi-packaging/issues/33
-  * d/p/ur-0005-fix-mock-adapter-discovery-static-linking.patch:
-  Fix mock used in unit testing.
-  https://github.com/canonical/oneapi-packaging/issues/33
-  * d/p/ur-0006-dont-call-xptiFrameworkFinalize-during-shutdown.patch:
-  Don't call xptiFrameworkFinalize during global shutdown as this causes
-  failures in unit tests when libur is built as a static lib.
-  https://github.com/canonical/oneapi-packaging/issues/33
-  * d/p/ur-0007-use-canonical-path-to-resolve-loader-lib-path.patch:
-  Fix an issue where libsycl is not finding the UR adapter libs in the
-  compiler-private directory.
-  * d/p/dpcpp-0001-add-in-source-versioning.patch:
-  Add in-source versioning to DPC++.
-  https://github.com/intel/llvm/issues/21509
-  * d/p/dpcpp-0002-add-self-macro-versioning.patch:
-  Add self-macro versioning to DPC++.
-  https://github.com/intel/llvm/issues/21510
-  * d/tests:
-    - Update tests to use new symlink names for DPC++ compiler.
-    https://github.com/canonical/oneapi-packaging/issues/34
-    - Add new tests for ensuring proper runtime dependency declaration in
-    d/control and accessibility of .bc files that enable certain compiler
-    features like sqrt operations.
-    https://github.com/canonical/oneapi-packaging/issues/38
-    - Bump minimum required version of CMake in a few tests to work with
-    the version of CMake in resolute.
-    - Add pkgconfig tests to verify that the pkgconfig file
-    is correctly installed and can be used to compile and link a
-    SYCL application with libsycl.
-    https://github.com/canonical/oneapi-packaging/issues/42
+  * Various improvements based on feedback from Intel (LP: #2146468):
+    - d/control:
+      - Update binary package names based on recommendations from Intel.
+        https://github.com/canonical/oneapi-packaging/issues/36
+      - Add missing runtime dependencies for dpclang-6 binary package.
+        https://github.com/canonical/oneapi-packaging/issues/30
+        https://github.com/canonical/oneapi-packaging/issues/31
+      - Remove libur-loader0 binary package since it's now built as a
+        static lib.
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Remove libur-adapter* binary packages and consolidate into a
+        single unified-runtime-adapters-dpcpp-6 binary package since
+        these libs are no longer in a public directory.
+        https://github.com/canonical/oneapi-packaging/issues/37
+      - Remove libur-loader* binary packages since this lib is
+        now built statically.
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Add dependency between libclang-dpcpp-6-dev and sycl-dpcpp-6-dev
+        since the clang development package now includes the unified runtime
+        loader headers that are needed for compiling SYCL applications.
+      - Add strict version constraints for all binary packages derived
+        from the same intel-dpcpp source package, with the exception of
+        libsycl8 since it may be used by multiple versions of DPC++.
+      - Add Replaces and Breaks fields where package names have changed
+        to ensure a smooth upgrade for users who have the previous package
+        names installed.
+    - d/rules:
+      - Remove spirv-to-ir-wrapper man page since it is no longer
+        in a public directory.
+        https://github.com/canonical/oneapi-packaging/issues/35
+      - Build unified runtime lib statically.
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Update man page names because name of public symlinks have changed;
+        update excluded private compiler path for dh_makeshlibs.
+        https://github.com/canonical/oneapi-packaging/issues/34
+    - d/*.{install,manpages,links}: update private compiler path from
+      /usr/lib/llvm-dpcpp-21 to /usr/lib/dpcpp-6/llvm
+      https://github.com/canonical/oneapi-packaging/issues/34
+    - d/dpclang-6.links:
+      - Update symlink names based on feedback from Intel.
+        https://github.com/canonical/oneapi-packaging/issues/34
+      - Remove spirv-to-ir-wrapper symlink since it is compiler-private.
+        https://github.com/canonical/oneapi-packaging/issues/35
+    - d/libsycl8.install:
+      - Install .spv files required for supporting
+        -fsycl-device-lib-jit-link option.
+        https://github.com/canonical/oneapi-packaging/issues/32
+      - Install versioned .so in private directory so it can find .spv
+        files at runtime.
+        https://github.com/canonical/oneapi-packaging/issues/32
+    - d/libsycl8.links: Sym link from public to private path.
+      https://github.com/canonical/oneapi-packaging/issues/32
+    - d/libsycl8.symbols: Update Build-Depends-Package field since
+      libsycl-dev is now sycl-dpcpp-6-dev.
+    - d/libsycl8.lintian-overrides: Add lintian-override and explain
+      why ldconfig trigger is not needed for private library.
+    - d/sycl-dpcpp-6-dev.install:
+      - Install .bc files required during compilation.
+        https://github.com/canonical/oneapi-packaging/issues/32
+      - Install sycl-dpcpp-6.pc pkgconfig file
+        https://github.com/canonical/oneapi-packaging/issues/42
+      - Remove redundant openCL header files from opencl-c-headers.
+        Keep CL/sycl.hpp for backwards compatibility.
+      - Migrate unified runtime loader header files and XPTI header
+        files to libclang-dpcpp-6-dev binary package.
+    - d/sycl-dpcpp-6-dev.links:
+      - Create development sym link manually since upstream
+        uses relative path.
+        https://github.com/canonical/oneapi-packaging/issues/32
+        https://github.com/canonical/oneapi-packaging/issues/35
+      - Move libsycl.so development symlink to compiler-private
+        directory to avoid future conflicts where a user may want
+        multiple versions of dpclang and libsycl installed at the
+        same time.
+      - Symlink to sycl-dpcpp-6.pc pkgconfig file
+        https://github.com/canonical/oneapi-packaging/issues/42
+    - d/sycl-dpcpp-6.pc: add pkgconfig file for libsycl, needed
+      for users who want to link with libsycl directly.
+    - d/p/series:
+      - Apply new patch for building libur as a static lib.
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Drop clang-0001-remove-cpp-driver-suffix.patch because new clang*
+        symlink names do not collid with any suffix names from upstream.
+        https://github.com/canonical/oneapi-packaging/issues/34
+      - Apply new patch for fixing mock in unit tests
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Apply new patch to remove xptiFrameworkFinalize call
+        https://github.com/canonical/oneapi-packaging/issues/33
+      - Apply new patch for resolving loader lib path.
+      - Apply patch for adding in source versioning to DPC++
+        https://github.com/intel/llvm/issues/21509
+      - Apply patch for adding self-macro versioning to DPC++
+        https://github.com/intel/llvm/issues/21510
+    - d/p/clang-0001-remove-cpp-driver-suffix.patch: drop patch
+      because new clang* symlink names do not collide with any suffix
+      names from upstream.
+      https://github.com/canonical/oneapi-packaging/issues/34
+    - d/p/ur-0004-fix-static-loader-when-building-in-tree.patch:
+      Build unified runtime loader as a static lib since its API/ABI
+      are unstable.
+      https://github.com/canonical/oneapi-packaging/issues/33
+    - d/p/ur-0005-fix-mock-adapter-discovery-static-linking.patch:
+      Fix mock used in unit testing.
+      https://github.com/canonical/oneapi-packaging/issues/33
+    - d/p/ur-0006-dont-call-xptiFrameworkFinalize-during-shutdown.patch:
+      Don't call xptiFrameworkFinalize during global shutdown as this
+      causes failures in unit tests when libur is built as a static lib.
+      https://github.com/canonical/oneapi-packaging/issues/33
+    - d/p/ur-0007-use-canonical-path-to-resolve-loader-lib-path.patch:
+      Fix an issue where libsycl is not finding the UR adapter libs in
+      the compiler-private directory.
+    - d/p/dpcpp-0001-add-in-source-versioning.patch:
+      Add in-source versioning to DPC++.
+      https://github.com/intel/llvm/issues/21509
+    - d/p/dpcpp-0002-add-self-macro-versioning.patch:
+      Add self-macro versioning to DPC++.
+      https://github.com/intel/llvm/issues/21510
+    - d/tests:
+      - Update tests to use new symlink names for DPC++ compiler.
+        https://github.com/canonical/oneapi-packaging/issues/34
+      - Add new tests for ensuring proper runtime dependency declaration in
+        d/control and accessibility of .bc files that enable certain compiler
+        features like sqrt operations.
+        https://github.com/canonical/oneapi-packaging/issues/38
+      - Bump minimum required version of CMake in a few tests to work with
+        the version of CMake in resolute.
+      - Add pkgconfig tests to verify that the pkgconfig file
+        is correctly installed and can be used to compile and link a
+        SYCL application with libsycl.
+        https://github.com/canonical/oneapi-packaging/issues/42
+    - d/s/lintian-overrides: Allow weak dependency between sycl-dpcpp-6-dev
+      and libsycl8.
 
  -- Will French <will.french@canonical.com>  Wed, 25 Mar 2026 13:33:45 -0500
 

--- a/onednn/debian/changelog
+++ b/onednn/debian/changelog
@@ -1,23 +1,25 @@
 onednn-sycl (3.11+dfsg-0ubuntu2) resolute; urgency=medium
 
-  * d/control:
-    - Update DPC++ binary package name in Build-Depends from
-      clang-dpcpp-21 to dpclang-6.
-    - Drop libsycl-dev and libclang-dpcpp-common-21-dev from
-      Build-Depends because these are runtime dependencies for
-      dpclang-6.
-    - Drop libur-adapter* runtime dependencies because these
-      have been replaced with the unified-runtime-adapters-dpcpp-6
-      binary package, which is now listed as a runtime dependency
-      instead.
-  * d/rules: use new names of DPC++ compiler commands, and new
-    path to compiler-private directory.
-  * d/tests:
-    - Use new names of DPC++ compiler commands.
-    - Update DPC++ binary package name in Depends from
-      clang-dpcpp-21 to dpclang-6.
-    - Drop libsycl-dev and libclang-dpcpp-common-21-dev from
-      Depends because these are runtime dependencies for dpclang-6.
+  * Update names of binary packages and compiler commands due to
+    changes in intel-dpcpp packaging (LP: #2146468):
+    - d/control:
+      - Update DPC++ binary package name in Build-Depends from
+        clang-dpcpp-21 to dpclang-6.
+      - Drop libsycl-dev and libclang-dpcpp-common-21-dev from
+        Build-Depends because these are runtime dependencies for
+        dpclang-6.
+      - Drop libur-adapter* runtime dependencies because these
+        have been replaced with the unified-runtime-adapters-dpcpp-6
+        binary package, which is now listed as a runtime dependency
+        instead.
+    - d/rules: use new names of DPC++ compiler commands, and new
+      path to compiler-private directory.
+    - d/tests:
+      - Use new names of DPC++ compiler commands.
+      - Update DPC++ binary package name in Depends from
+        clang-dpcpp-21 to dpclang-6.
+      - Drop libsycl-dev and libclang-dpcpp-common-21-dev from
+        Depends because these are runtime dependencies for dpclang-6.
 
  -- Will French <will.french@canonical.com>  Wed, 25 Mar 2026 17:17:44 -0500
 

--- a/onedpl/debian/changelog
+++ b/onedpl/debian/changelog
@@ -1,13 +1,15 @@
 onedpl (2022.9.0-0ubuntu6) resolute; urgency=medium
 
-  * d/tests:
-    - Update binary package name for DPC++ compiler from
-    clang-dpcpp-21 to dpclang-6.
-    - Update DPC++ compiler name from clang++-dpcpp to
-    dpclang++.
-  * d/changelog: drop ~26.04 suffix from version as this
-  was intended to be dropped when the package migrated
-  from a PPA to the archive.
+  * Update names of binary packages and compiler commands due to
+    changes in intel-dpcpp packaging (LP: #2146468):
+    - d/tests:
+      - Update binary package name for DPC++ compiler from
+        clang-dpcpp-21 to dpclang-6.
+      - Update DPC++ compiler name from clang++-dpcpp to
+        dpclang++.
+    - d/changelog: drop ~26.04 suffix from version as this
+      was intended to be dropped when the package migrated
+      from a PPA to the archive.
 
  -- Will French <will.french@canonical.com>  Fri, 20 Mar 2026 13:13:24 -0500
 

--- a/umf/debian/changelog
+++ b/umf/debian/changelog
@@ -1,35 +1,11 @@
-intel-umf (0.11.0-0ubuntu5~26.04) resolute; urgency=medium
-
-  * Initial package upload (LP: #2130189).
-    - d/watch: produce consistent parent folder name in orig tarball
-      using v5 d/watch.
-
- -- Will French <will.french@canonical.com>  Wed, 25 Feb 2026 10:46:59 -0600
-
-intel-umf (0.11.0-0ubuntu4~26.04) resolute; urgency=medium
-
-  * Initial package upload (LP: #2130189).
-    - d/copyright: improve accuracy of license reporting.
-    - d/watch: upgrade to version 5.
-
- -- Will French <will.french@canonical.com>  Tue, 24 Feb 2026 14:35:49 -0600
-
-intel-umf (0.11.0-0ubuntu3~26.04) resolute; urgency=medium
-
-  * Initial package upload (LP: #2130189).
-    - d/copyright: add files flagged by licensecheck -r. 
-
- -- Will French <will.french@canonical.com>  Mon, 02 Feb 2026 12:16:13 -0600
-
-intel-umf (0.11.0-0ubuntu2~26.04) resolute; urgency=medium
-
-  * Initial package upload (LP: #2130189).
-    - d/intel-umf0.symbols: Add symbols control file for libumf0.
-
- -- Will French <will.french@canonical.com>  Wed, 14 Jan 2026 10:34:02 -0600
-
 intel-umf (0.11.0-0ubuntu1~26.04) resolute; urgency=medium
 
   * Initial package upload (LP: #2130189).
+    - d/watch: upgrade to version 5.
+    - d/watch: produce consistent parent folder name in orig tarball
+      using v5 d/watch.
+    - d/copyright: add files flagged by licensecheck -r.
+    - d/copyright: improve accuracy of license reporting.
+    - d/intel-umf0.symbols: Add symbols control file for libumf0.
 
- -- Will French <will.french@canonical.com>  Mon, 12 Jan 2026 14:10:55 -0600
+ -- Will French <will.french@canonical.com>  Wed, 25 Feb 2026 10:46:59 -0600


### PR DESCRIPTION
This primarily updates the repo's top-level README.md to update the status of the project (now that several packages have landed in 26.04).

I also synced the `debian/changelog` files to accurately reflect what is now in Ubuntu.